### PR TITLE
0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.2
+
+### Changed
+
+- Limit the size of virtual assets by ignoring prefabs and scriptable objects past a certain depth
+
+### Fixed
+
+- Fix prefab imports sometimes throwing component-related errors; temporary components are no longer used to lookup scripts
+
 ## 0.2.1
 
 ### Fixed

--- a/Editor/Util/ImportUtil.cs
+++ b/Editor/Util/ImportUtil.cs
@@ -1,4 +1,7 @@
-﻿using UnityEditor;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
 using UnityEditor.AssetImporters;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -7,6 +10,15 @@ namespace AssetsOfRain.Editor.Util
 {
     public static class ImportUtil
     {
+        public static MonoScript FindScript(Type classType)
+        {
+            return AssetDatabase.FindAssets($"t:{nameof(MonoScript)}")
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Distinct()
+                .SelectMany(x => AssetDatabase.LoadAllAssetsAtPath(x).OfType<MonoScript>())
+                .FirstOrDefault(x => x.GetClass() == classType);
+        }
+
         public static void SetScriptReference(Object asset, MonoScript monoScript)
         {
             const string SCRIPT_PROPERTY = "m_Script";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": ""
   },
   "displayName": "Assets of Rain",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "unity": "2021.3",
   "description": "A ThunderKit package for building Risk of Rain 2 mods that depend on addressable assets, with full editor support",
   "dependencies": {


### PR DESCRIPTION
### Changed

- Limit the size of virtual assets by ignoring prefabs and scriptable objects past a certain depth

### Fixed

- Fix prefab imports sometimes throwing component-related errors; temporary components are no longer used to lookup scripts
