### PR TITLE
0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.4
+
+### Changed
+
+- Update virtual asset paths to use a shorter "type hash" based on the asset type and file extension rather than using the type name directly
+
+### Fixed
+
+- Fix virtual asset path conflicts caused by multiple file extensions mapping to the same asset type
+
 ## 0.2.3
 
 ### Added

--- a/Editor/VirtualAssets/VirtualAddressableAssetCollection.cs
+++ b/Editor/VirtualAssets/VirtualAddressableAssetCollection.cs
@@ -27,8 +27,13 @@ namespace AssetsOfRain.Editor.VirtualAssets
         public string GetVirtualAssetPath(SerializableAssetRequest assetRequest)
         {
             string virtualAssetDirectory = Path.Combine(directory, Path.GetDirectoryName(assetRequest.primaryKey));
+
+            Hash128 typeHash = Hash128.Compute(assetRequest.assemblyQualifiedTypeName);
+            typeHash.Append(Path.GetExtension(assetRequest.primaryKey));
+
             string virtualAssetFileName = Path.ChangeExtension(Path.GetFileName(assetRequest.primaryKey), VirtualAddressableAssetImporter.EXTENSION);
-            return Path.Combine(virtualAssetDirectory, assetRequest.assemblyQualifiedTypeName, virtualAssetFileName);
+            
+            return Path.Combine(virtualAssetDirectory, typeHash.ToString(), virtualAssetFileName);
         }
 
         public void ImportVirtualAsset(SerializableAssetRequest assetRequest)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": ""
   },
   "displayName": "Assets of Rain",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "unity": "2021.3",
   "description": "A ThunderKit package for building Risk of Rain 2 mods that depend on addressable assets, with full editor support",
   "dependencies": {


### PR DESCRIPTION
### Changed

- Update virtual asset paths to use a shorter "type hash" based on the asset type and file extension rather than using the type name directly

### Fixed

- Fix #14  virtual asset path conflicts caused by multiple file extensions mapping to the same asset type